### PR TITLE
Removed old PPA URL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ CMD ["/usr/local/bin/supervisord", "-c", "/etc/supervisord.conf"]
 
 # Install required packages
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E5267A6C C300EE8C && \
-	echo 'deb http://ppa.launchpad.net/ondrej/php-7.0/ubuntu trusty main' > /etc/apt/sources.list.d/ondrej-php7.list && \
+	echo 'deb http://ppa.launchpad.net/ondrej/php/ubuntu trusty main' > /etc/apt/sources.list.d/ondrej-php7.list && \
 	echo 'deb http://ppa.launchpad.net/nginx/development/ubuntu trusty main' > /etc/apt/sources.list.d/nginx.list && \
 	apt-get update && apt-get install -y \
 		curl \


### PR DESCRIPTION
The PPA URL has been updated to the new URL. This was changed at the end of February.

https://launchpad.net/~ondrej/+archive/ubuntu/php
https://webcache.googleusercontent.com/search?q=cache:X3m8CmJDMDUJ:https://launchpad.net/~ondrej/%2Barchive/ubuntu/php-7.0+&cd=1&hl=en&ct=clnk&gl=us
